### PR TITLE
networking/dnsovertls: init with systemd-resolved

### DIFF
--- a/hosts/athena/default.nix
+++ b/hosts/athena/default.nix
@@ -76,7 +76,6 @@
       enable = true;
     };
     services = {
-      dnsoverhttps.enable = true;
       healthchecks = {
         enable = true;
       };

--- a/hosts/athena/default.nix
+++ b/hosts/athena/default.nix
@@ -1,6 +1,5 @@
 # Configuration for athena (VPS)
 {
-  config,
   lib,
   pkgs,
   profiles,
@@ -46,22 +45,6 @@
   boot.tmp.cleanOnBoot = true;
 
   # Network Configuration
-  # Configure static IPv6 address
-  networking = {
-    interfaces = {
-      ${config.my.networking.wiredInterface}.ipv6.addresses = [
-        {
-          address = "2001:41d0:20a:900::7e7";
-          prefixLength = 64;
-        }
-      ];
-    };
-    defaultGateway6 = {
-      address = "2001:41d0:20a:900::";
-      interface = config.my.networking.wiredInterface;
-    };
-  };
-
   my.networking.wiredInterface = "ens3";
 
   # PostgreSQL

--- a/hosts/bro/default.nix
+++ b/hosts/bro/default.nix
@@ -45,7 +45,6 @@
       enable = true;
     };
     services = {
-      dnsoverhttps.enable = true;
       healthchecks = {
         enable = true;
       };

--- a/hosts/feb/default.nix
+++ b/hosts/feb/default.nix
@@ -40,7 +40,6 @@
       enable = true;
     };
     services = {
-      dnsoverhttps.enable = true;
       healthchecks = {
         enable = true;
       };

--- a/hosts/hera/default.nix
+++ b/hosts/hera/default.nix
@@ -62,7 +62,6 @@
       enable = true;
     };
     services = {
-      dnsoverhttps.enable = true;
       healthchecks = {
         enable = true;
       };

--- a/hosts/phobos/default.nix
+++ b/hosts/phobos/default.nix
@@ -1,6 +1,5 @@
 # Configuration for phobos (VPS)
 {
-  config,
   pkgs,
   profiles,
   ...
@@ -25,18 +24,6 @@
   boot.tmp.cleanOnBoot = true;
 
   # Network Configuration
-  # Configure static IPv6 address
-  networking = {
-    interfaces = {
-      ${config.my.networking.wiredInterface}.ipv6.addresses = [
-        {
-          address = "2a03:4000:2a:1b3::";
-          prefixLength = 64;
-        }
-      ];
-    };
-  };
-
   my.networking.wiredInterface = "ens3";
 
   # PostgreSQL

--- a/hosts/phobos/default.nix
+++ b/hosts/phobos/default.nix
@@ -51,7 +51,6 @@
       enable = true;
     };
     services = {
-      dnsoverhttps.enable = true;
       healthchecks = {
         enable = true;
       };

--- a/hosts/zeus/default.nix
+++ b/hosts/zeus/default.nix
@@ -57,7 +57,6 @@
   modules = {
     server.enable = true;
     services = {
-      dnsoverhttps.enable = true;
       healthchecks.enable = true;
       # Nebula (VPN)
       nebula = {

--- a/hosts/zeus/default.nix
+++ b/hosts/zeus/default.nix
@@ -1,6 +1,5 @@
 # Configuration for zeus (VPS)
 {
-  config,
   lib,
   pkgs,
   profiles,
@@ -29,22 +28,6 @@
   boot.tmp.cleanOnBoot = true;
 
   # Network Configuration
-  # Configure static IPv6 address
-  networking = {
-    interfaces = {
-      ${config.my.networking.wiredInterface}.ipv6.addresses = [
-        {
-          address = "2001:41d0:304:200::c76d";
-          prefixLength = 64;
-        }
-      ];
-    };
-    defaultGateway6 = {
-      address = "2001:41d0:304:200::1";
-      interface = config.my.networking.wiredInterface;
-    };
-  };
-
   my.networking.wiredInterface = "ens3";
 
   # PostgreSQL

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -79,6 +79,7 @@
   time.timeZone = lib.mkDefault "Europe/Lisbon";
 
   networking.domain = lib.mkDefault "diogotc.com";
+  networking.search = lib.mkDefault [ config.networking.domain ];
 
   services.journald.extraConfig = ''
     SystemMaxUse=500M

--- a/profiles/meta/server.nix
+++ b/profiles/meta/server.nix
@@ -5,5 +5,9 @@
     meta.common
 
     monitoring.prometheus-exporters.node
+    networking.dnsovertls
   ];
+
+  # Use a modern network configuration backend instead of legacy scripts
+  networking.useNetworkd = true;
 }

--- a/profiles/networking/dnsovertls.nix
+++ b/profiles/networking/dnsovertls.nix
@@ -1,0 +1,49 @@
+# Configure systemd-resolved to use DNS over TLS
+{
+  config,
+  ...
+}:
+let
+  upstream = [
+    # cloudflare
+    "1.1.1.1#cloudflare-dns.com"
+    "2606:4700:4700::1111#cloudflare-dns.com"
+
+  ];
+  fallback = [
+    # cloudflare
+    "1.0.0.1#cloudflare-dns.com"
+    "2606:4700:4700::1001#cloudflare-dns.com"
+
+    # mullvad
+    "194.242.2.2#dns.mullvad.net"
+    "2a07:e340::2#dns.mullvad.net"
+
+    # quad9
+    "9.9.9.9#dns.quad9.net"
+    "149.112.112.112#dns.quad9.net"
+    "2620:fe::fe#dns.quad9.net"
+    "2620:fe::9#dns.quad9.net"
+
+    # google
+    "8.8.8.8#dns.google"
+    "8.8.4.4#dns.google"
+    "2001:4860:4860::8888#dns.google"
+    "2001:4860:4860::8844#dns.google"
+  ];
+in
+{
+  networking.nameservers = upstream;
+
+  services.resolved = {
+    enable = true;
+    dnsovertls = "true";
+    dnssec = "true";
+    extraConfig = ''
+      Cache=yes
+      DNSSEC=yes
+    '';
+    fallbackDns = fallback;
+    domains = config.networking.search ++ [ "~." ]; # Force all queries to use the dnsproxy
+  };
+}


### PR DESCRIPTION
This has many problems:
- IPv6 DHCP is not actually working (might need to revert that commit)
- systemd-resolved only picks a single resolver at a time and stays with that resolver until it fails
- systemd-resolved does not detect when IPv6 is not available and gets stuck with an IPv6 anyway (possibly related https://github.com/systemd/systemd/issues/38913)
- DNS servers from DHCP are still used
- `FallbackDNS` are not actually used as fallback for failures, they are only used when no other DNS server is configured (which is never the case)