### PR TITLE
treewide: use finalAttrs pattern in buildPython{Package,Application}

### DIFF
--- a/packages/cybersec/flask-unsign.nix
+++ b/packages/cybersec/flask-unsign.nix
@@ -4,14 +4,14 @@
   python3Packages,
   ...
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "flask-unsign";
   version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Paradoxis";
     repo = "Flask-Unsign";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6V5R/wTjxYX894Ep/8G2Vz/v8ZpXlCLpxKuhGCs+Xa0=";
   };
 
@@ -32,4 +32,4 @@ python3Packages.buildPythonApplication rec {
     license = licenses.mit;
     platforms = platforms.linux;
   };
-}
+})

--- a/packages/cybersec/jwt-tool.nix
+++ b/packages/cybersec/jwt-tool.nix
@@ -4,14 +4,14 @@
   python3Packages,
   ...
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "jwt-tool";
   version = "2.2.7";
 
   src = fetchFromGitHub {
     owner = "ticarpi";
     repo = "jwt_tool";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-byLw1ppvRdppADufsxcRRxW0uyDT6Y0EDTCrw5hxK0Y=";
   };
 
@@ -34,4 +34,4 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3;
     platforms = platforms.linux;
   };
-}
+})

--- a/packages/cybersec/libdebug.nix
+++ b/packages/cybersec/libdebug.nix
@@ -11,12 +11,12 @@
   zstd,
   ...
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "libdebug";
   version = "0.9.0";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-rk2Cq7YpN/z530LAFzWKm1I33j24rsSKbQV7Ezv5E34=";
   };
 
@@ -59,4 +59,4 @@ python3Packages.buildPythonPackage rec {
     license = licenses.mit;
     platforms = platforms.linux;
   };
-}
+})

--- a/packages/cybersec/netfilterqueue.nix
+++ b/packages/cybersec/netfilterqueue.nix
@@ -6,14 +6,14 @@
   python3Packages,
   ...
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "netfilterqueue";
   version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "oremanj";
     repo = "python-netfilterqueue";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2/EF+WGy5SjunaMonQmN2TQ8G5awh1Cvn90LRx7QS9k=";
   };
 
@@ -32,4 +32,4 @@ python3Packages.buildPythonPackage rec {
     license = licenses.mit;
     platforms = platforms.linux;
   };
-}
+})

--- a/packages/cybersec/pyinstxtractor.nix
+++ b/packages/cybersec/pyinstxtractor.nix
@@ -4,14 +4,14 @@
   python3Packages,
   ...
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyinstxtractor";
   version = "2024.04";
 
   src = fetchFromGitHub {
     owner = "extremecoders-re";
     repo = "pyinstxtractor";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Wx/q67mkbAEfraSL/37PICa4zLn5O/2oCiLzwMLU4M8=";
   };
 
@@ -32,4 +32,4 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3;
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Can only be merged after NixOS 26.05 is released.